### PR TITLE
feat!: add `handle_connect/2` callback

### DIFF
--- a/lib/minch.ex
+++ b/lib/minch.ex
@@ -9,6 +9,7 @@ defmodule Minch do
                 |> List.last())
 
   @type client :: GenServer.server()
+  @type response_map :: %{status: Mint.Types.status(), headers: Mint.Types.headers()}
 
   @doc """
   Invoked when the client process is started.
@@ -38,7 +39,7 @@ defmodule Minch do
   @doc """
   Invoked to handle a successful connection.
   """
-  @callback handle_connect(state :: term()) ::
+  @callback handle_connect(response :: response_map(), state :: term()) ::
               {:ok, new_state}
               | {:reply, frame :: Mint.WebSocket.frame(), new_state}
             when new_state: term()

--- a/test/minch_test.exs
+++ b/test/minch_test.exs
@@ -55,8 +55,8 @@ defmodule MinchTest do
       :ok
     end
 
-    def handle_connect(state) do
-      send(state.receiver, {:ws_client_connect, state})
+    def handle_connect(response, state) do
+      send(state.receiver, {:ws_client_connect, response})
       {:reply, :ping, state}
     end
 
@@ -99,7 +99,7 @@ defmodule MinchTest do
       assert_receive {:ws_client_init, _}
 
       # handle_connect
-      assert_receive {:ws_client_connect, _}
+      assert_receive {:ws_client_connect, %{status: 101, headers: _}}
 
       # reply from handle_connect
       assert_receive {:ws_server_frame, :ping}


### PR DESCRIPTION
Make the response status map available in the `handle_connect/2` callback