### PR TITLE
feat!: rewrite using gen_server

### DIFF
--- a/lib/minch.ex
+++ b/lib/minch.ex
@@ -4,7 +4,7 @@ defmodule Minch do
              |> String.split("<!-- @moduledoc -->")
              |> List.last()
 
-  @type client :: :gen_statem.server_ref()
+  @type client :: GenServer.server()
   @type state :: term()
   @type response :: %{status: Mint.Types.status(), headers: Mint.Types.headers()}
   @type frame :: Mint.WebSocket.frame() | Mint.WebSocket.shorthand_frame()
@@ -12,7 +12,7 @@ defmodule Minch do
   @type callback_result ::
           {:ok, state()}
           | {:reply, frame() | [frame()], state()}
-          | {:stop, reason :: term()}
+          | {:stop, reason :: term(), state()}
 
   @doc """
   Invoked when the client process is started.
@@ -47,7 +47,7 @@ defmodule Minch do
   """
   @callback handle_disconnect(reason :: term(), attempt :: pos_integer(), state()) ::
               {:reconnect, backoff :: pos_integer(), state()}
-              | {:stop, reason :: term()}
+              | {:stop, reason :: term(), state()}
 
   @doc """
   Invoked to handle internal errors.
@@ -68,7 +68,7 @@ defmodule Minch do
   @doc """
   Starts a `Minch` client process linked to the current process.
   """
-  @spec start_link(module(), term(), [:gen_statem.start_opt()]) :: :gen_statem.start_ret()
+  @spec start_link(module(), term(), GenServer.options()) :: GenServer.on_start()
   def start_link(module, init_arg, opts \\ []) do
     Minch.Conn.start_link(module, init_arg, opts)
   end
@@ -116,7 +116,7 @@ defmodule Minch do
   @spec send_frame(client(), Mint.WebSocket.frame() | Mint.WebSocket.shorthand_frame()) ::
           :ok | {:error, term()}
   def send_frame(client, frame) do
-    :gen_statem.call(client, {:send_frame, frame})
+    GenServer.call(client, {:send_frame, frame})
   end
 
   @doc """

--- a/lib/minch/conn.ex
+++ b/lib/minch/conn.ex
@@ -1,63 +1,47 @@
 defmodule Minch.Conn do
   @moduledoc false
-  @behaviour :gen_statem
+  use GenServer
 
-  defmodule Data do
-    @moduledoc false
-    defstruct [
-      :conn,
-      :conn_attempt,
-      :websocket,
-      :request_ref,
-      :response_status,
-      :response_headers,
-      :callback,
-      :callback_state
-    ]
-  end
+  alias __MODULE__, as: State
 
-  @spec start_link(module(), term(), [:gen_statem.start_opt()]) :: :gen_statem.start_ret()
+  defstruct [
+    :conn,
+    :conn_attempt,
+    :request_ref,
+    :response_status,
+    :websocket,
+    :callback,
+    :callback_state,
+    :reconnect_timer
+  ]
+
+  @internal :"$minch"
+
+  @spec start_link(module(), term(), GenServer.options()) :: GenServer.on_start()
   def start_link(module, init_arg, opts \\ []) do
-    apply(:gen_statem, :start_link, start_args(module, init_arg, opts))
+    GenServer.start_link(__MODULE__, {module, init_arg}, opts)
   end
 
-  @spec start_link(module(), term(), [:gen_statem.start_opt()]) :: :gen_statem.start_ret()
+  @spec start(module(), term(), GenServer.options()) :: GenServer.on_start()
   def start(module, init_arg, opts \\ []) do
-    apply(:gen_statem, :start, start_args(module, init_arg, opts))
+    GenServer.start(__MODULE__, {module, init_arg}, opts)
   end
 
-  @spec stop(:gen_statem.server_ref()) :: :ok
+  @spec stop(GenServer.server()) :: :ok
   def stop(conn) do
-    :gen_statem.stop(conn)
+    GenServer.stop(conn)
   end
-
-  defp start_args(module, init_arg, opts) do
-    {name, opts} = Keyword.pop(opts, :name)
-    args = [__MODULE__, {module, init_arg}, opts]
-
-    case name do
-      nil -> args
-      name when is_atom(name) -> [{:local, name} | args]
-      name -> [name | args]
-    end
-  end
-
-  @impl true
-  def callback_mode(), do: :state_functions
 
   @impl true
   def init({callback, init_arg}) do
     case callback.init(init_arg) do
-      {:ok, state} ->
+      {:ok, callback_state} ->
+        state = %State{callback: callback, callback_state: callback_state, conn_attempt: 0}
         Process.flag(:trap_exit, true)
-        data = %Data{callback: callback, callback_state: state, conn_attempt: 0}
-        {:ok, :disconnected, data, {:next_event, :internal, :connect}}
+        {:ok, state, {:continue, :connect}}
 
-      {:error, _reason} = error ->
-        error
-
-      {:stop, _reson} = stop ->
-        stop
+      {:error, reason} ->
+        {:error, reason}
 
       :ignore ->
         :ignore
@@ -65,24 +49,16 @@ defmodule Minch.Conn do
   end
 
   @impl true
-  def terminate(reason, _state, %Data{} = data) do
-    if data.websocket, do: send_frame(data, :close)
-    if data.conn, do: Mint.HTTP.close(data.conn)
-    data.callback.terminate(reason, data.callback_state)
+  def terminate(reason, %State{} = state) do
+    if state.websocket, do: send_frame(state, :close)
+    if state.conn, do: Mint.HTTP.close(state.conn)
+    state.callback.terminate(reason, state.callback_state)
   end
 
-  @doc false
-  def disconnected(:info, message, data) do
-    handle_info(message, data)
-  end
-
-  def disconnected({:call, from}, {:send_frame, _frame}, data) do
-    {:keep_state, data, {:reply, from, {:error, :not_connected}}}
-  end
-
-  def disconnected(:internal, :connect, %Data{} = data) do
+  @impl true
+  def handle_continue(:connect, %State{} = state) do
     {url, headers, options} =
-      case data.callback.connect(data.callback_state) do
+      case state.callback.connect(state.callback_state) do
         {url, headers, options} -> {url, headers, options}
         {url, headers} -> {url, headers, []}
         url -> {url, [], []}
@@ -116,182 +92,169 @@ defmodule Minch.Conn do
 
     with {:ok, conn} <- Mint.HTTP.connect(http_scheme, url.host, url.port, connect_opts),
          {:ok, conn, ref} <- Mint.WebSocket.upgrade(ws_scheme, conn, path, headers, upgrade_opts) do
-      {:keep_state, %{data | conn: conn, conn_attempt: 1, request_ref: ref}}
+      {:noreply, %{state | conn: conn, conn_attempt: 1, request_ref: ref}}
     else
       {:error, error} ->
-        handle_disconnect(error, %{data | conn_attempt: data.conn_attempt + 1})
+        handle_disconnect(error, %{state | conn_attempt: state.conn_attempt + 1})
 
       {:error, conn, error} ->
-        Mint.HTTP.close(conn)
-        handle_disconnect(error, %{data | conn_attempt: data.conn_attempt + 1})
+        {:ok, conn} = Mint.HTTP.close(conn)
+        handle_disconnect(error, %{state | conn_attempt: state.conn_attempt + 1, conn: conn})
     end
   end
 
-  def disconnected(:internal, {:status, ref, status}, %Data{request_ref: ref} = data) do
-    {:keep_state, %{data | response_status: status}}
+  @impl true
+  def handle_call({:send_frame, _frame}, _from, %State{websocket: nil} = state) do
+    {:reply, {:error, :not_connected}, state}
   end
 
-  def disconnected(:internal, {:headers, ref, headers}, %Data{request_ref: ref} = data) do
-    case Mint.WebSocket.new(data.conn, ref, data.response_status, headers) do
-      {:ok, conn, websocket} ->
-        data = %{data | conn: conn, websocket: websocket, response_headers: headers}
-        response = %{status: data.response_status, headers: headers}
-        {data, actions} = callback(data, :handle_connect, [response, data.callback_state])
-        {:next_state, :connected, data, actions}
-
-      {:error, conn, error} ->
-        Mint.HTTP.close(conn)
-        handle_disconnect(error, %{data | conn: nil})
+  def handle_call({:send_frame, frame}, _from, state) do
+    case send_frame(state, frame) do
+      {:ok, state} -> {:reply, :ok, state}
+      {:error, state, error} -> {:reply, {:error, error}, state}
     end
   end
 
-  def disconnected(:internal, {:data, ref, _}, %Data{request_ref: ref}) do
-    :keep_state_and_data
+  @impl true
+  def handle_info({@internal, {:handle_response, msg}}, state) do
+    handle_response(msg, state)
   end
 
-  def disconnected(:internal, {:error, ref, error}, %Data{request_ref: ref} = data) do
-    handle_error({:response, error}, data)
+  def handle_info({@internal, {:handle_frame, frame}}, state) do
+    handle_frame(frame, state)
   end
 
-  def disconnected(:internal, {:done, ref}, %Data{request_ref: ref}) do
-    :keep_state_and_data
-  end
-
-  def disconnected(:internal, {:stop, reason}, _data) do
-    {:stop, reason}
-  end
-
-  def disconnected(:internal, {:send_frame, _frame}, data) do
-    handle_error({:send_frame, :not_connected}, data)
-  end
-
-  def disconnected(:state_timeout, :reconnect, data) do
-    {:keep_state, data, {:next_event, :internal, :connect}}
-  end
-
-  @doc false
-  def connected(:info, message, data) do
-    handle_info(message, data)
-  end
-
-  def connected({:call, from}, {:send_frame, frame}, data) do
-    case send_frame(data, frame) do
-      {:ok, data} ->
-        {:keep_state, data, {:reply, from, :ok}}
-
-      {:error, data, error} ->
-        {:keep_state, data, {:reply, from, {:error, error}}}
+  def handle_info({@internal, {:send_frame, frame}}, state) do
+    case send_frame(state, frame) do
+      {:ok, state} -> {:noreply, state}
+      {:error, state, error} -> handle_error(error, state)
     end
   end
 
-  def connected(:internal, {:data, ref, bin}, %Data{request_ref: ref} = data) do
-    case Mint.WebSocket.decode(data.websocket, bin) do
-      {:ok, websocket, frames} ->
-        data = %{data | websocket: websocket}
-        actions = Enum.map(frames, &{:next_event, :internal, {:frame, &1}})
-        {:keep_state, data, actions}
-
-      {:error, websocket, error} ->
-        handle_error({:decode_frame, error}, %{data | websocket: websocket})
-    end
+  def handle_info({@internal, :reconnect}, %State{} = state) do
+    {:noreply, %{state | reconnect_timer: nil}, {:continue, :connect}}
   end
 
-  def connected(:internal, {:frame, frame}, data) do
-    handle_frame(frame, data)
-  end
-
-  def connected(:internal, {:error, ref, error}, %Data{request_ref: ref} = data) do
-    handle_error({:response, error}, data)
-  end
-
-  def connected(:internal, {:done, ref}, %Data{request_ref: ref}) do
-    :keep_state_and_data
-  end
-
-  def connected(:internal, {:stop, reason}, _data) do
-    {:stop, reason}
-  end
-
-  def connected(:internal, {:send_frame, frame}, data) do
-    case send_frame(data, frame) do
-      {:ok, data} -> {:keep_state, data}
-      {:error, data, error} -> handle_error({:send_frame, error}, data)
-    end
-  end
-
-  defp handle_info(message, %Data{} = data) do
-    case Mint.WebSocket.stream(data.conn, message) do
+  def handle_info(message, %State{} = state) do
+    case Mint.WebSocket.stream(state.conn, message) do
       {:ok, conn, responses} ->
-        actions = Enum.map(responses, &{:next_event, :internal, &1})
-        {:keep_state, %{data | conn: conn}, actions}
+        for msg <- responses, do: internal_event({:handle_response, msg})
+        {:noreply, %{state | conn: conn}}
 
-      {:error, conn, error, responses} ->
-        handle_error({:stream_response, error, responses}, %{data | conn: conn})
+      {:error, conn, error, _responses} ->
+        {:ok, conn} = Mint.HTTP.close(conn)
+        handle_disconnect(error, %{state | conn: conn})
 
       :unknown ->
-        {data, actions} = callback(data, :handle_info, [message, data.callback_state])
-        {:keep_state, data, actions}
+        callback(state, :handle_info, [message, state.callback_state])
     end
   end
 
-  defp handle_frame({:close, _, _} = frame, %Data{} = data) do
-    Mint.HTTP.close(data.conn)
-    handle_disconnect(frame, %{data | conn: nil, websocket: nil})
+  defp handle_response({:data, _, _}, %State{websocket: nil} = state) do
+    {:noreply, state}
   end
 
-  defp handle_frame({:ping, bin}, data) do
-    {:keep_state, data, {:next_event, :internal, {:send_frame, {:pong, bin}}}}
-  end
+  defp handle_response({:data, ref, data}, %State{request_ref: ref} = state) do
+    case Mint.WebSocket.decode(state.websocket, data) do
+      {:ok, websocket, frames} ->
+        for frame <- frames, do: internal_event({:handle_frame, frame})
+        {:noreply, %{state | websocket: websocket}}
 
-  defp handle_frame(frame, %Data{} = data) do
-    {data, actions} = callback(data, :handle_frame, [frame, data.callback_state])
-    {:keep_state, data, actions}
-  end
-
-  defp handle_error(error, %Data{} = data) do
-    {data, actions} = callback(data, :handle_error, [error, data.callback_state])
-    {:keep_state, data, actions}
-  end
-
-  defp handle_disconnect(error, %Data{} = data) do
-    case data.callback.handle_disconnect(error, data.conn_attempt, data.callback_state) do
-      {:reconnect, backoff, state} ->
-        data = %{data | callback_state: state}
-        actions = [{:state_timeout, backoff, :reconnect}]
-        {:next_state, :disconnected, data, actions}
-
-      {:stop, reason} ->
-        {:stop, reason}
+      {:error, websocket, error} ->
+        handle_error({:decode_frame, error}, %{state | websocket: websocket})
     end
   end
 
-  defp callback(%Data{} = data, name, args) do
-    case apply(data.callback, name, args) do
-      {:ok, state} ->
-        {%{data | callback_state: state}, []}
+  defp handle_response({:status, ref, status}, %State{request_ref: ref} = state) do
+    {:noreply, %{state | response_status: status}}
+  end
 
-      {:reply, frames, state} ->
-        actions = frames |> List.wrap() |> Enum.map(&{:next_event, :internal, {:send_frame, &1}})
-        {%{data | callback_state: state}, actions}
+  defp handle_response({:headers, ref, headers}, %State{request_ref: ref} = state) do
+    case Mint.WebSocket.new(state.conn, ref, state.response_status, headers) do
+      {:ok, conn, websocket} ->
+        state = %{state | conn: conn, websocket: websocket}
+        response = %{status: state.response_status, headers: headers}
+        callback(state, :handle_connect, [response, state.callback_state])
 
-      {:stop, reason} ->
-        {data, {:next_event, :internal, {:stop, reason}}}
+      {:error, conn, error} ->
+        {:ok, conn} = Mint.HTTP.close(conn)
+        handle_disconnect(error, %{state | conn: conn})
     end
   end
 
-  defp send_frame(%Data{} = data, frame) do
-    case Mint.WebSocket.encode(data.websocket, frame) do
+  defp handle_response({:error, ref, error}, %State{request_ref: ref} = state) do
+    handle_error({:response, error}, state)
+  end
+
+  defp handle_response({:done, ref}, %State{request_ref: ref} = state) do
+    {:noreply, state}
+  end
+
+  defp handle_frame({:close, _, _} = frame, %State{} = state) do
+    {:ok, conn} = Mint.HTTP.close(state.conn)
+    handle_disconnect(frame, %{state | conn: conn})
+  end
+
+  defp handle_frame({:ping, data}, %State{} = state) do
+    internal_event({:send_frame, {:pong, data}})
+    {:noreply, state}
+  end
+
+  defp handle_frame(frame, %State{} = data) do
+    callback(data, :handle_frame, [frame, data.callback_state])
+  end
+
+  defp handle_disconnect(error, %State{} = state) do
+    case state.callback.handle_disconnect(error, state.conn_attempt, state.callback_state) do
+      {:reconnect, backoff, callback_state} ->
+        if timer = state.reconnect_timer, do: Process.cancel_timer(timer)
+        timer = internal_event(:reconnect, backoff)
+        {:noreply, %{state | callback_state: callback_state, reconnect_timer: timer}}
+
+      {:stop, reason, callback_state} ->
+        {:stop, reason, %{state | callback_state: callback_state}}
+    end
+  end
+
+  defp handle_error(error, %State{} = state) do
+    callback(state, :handle_error, [error, state.callback_state])
+  end
+
+  defp callback(%State{} = state, name, args) do
+    case apply(state.callback, name, args) do
+      {:ok, callback_state} ->
+        {:noreply, %{state | callback_state: callback_state}}
+
+      {:reply, frames, callback_state} ->
+        for frame <- List.wrap(frames), do: internal_event({:send_frame, frame})
+        {:noreply, %{state | callback_state: callback_state}}
+
+      {:stop, reason, callback_state} ->
+        {:stop, reason, %{state | callback_state: callback_state}}
+    end
+  end
+
+  defp send_frame(%State{} = state, frame) do
+    case Mint.WebSocket.encode(state.websocket, frame) do
       {:ok, websocket, bin} ->
-        case Mint.WebSocket.stream_request_body(data.conn, data.request_ref, bin) do
+        case Mint.WebSocket.stream_request_body(state.conn, state.request_ref, bin) do
           {:ok, conn} ->
-            {:ok, %{data | conn: conn, websocket: websocket}}
+            {:ok, %{state | conn: conn, websocket: websocket}}
 
           {:error, conn, error} ->
-            {:error, %{data | conn: conn, websocket: websocket}, error}
+            {:error, %{state | conn: conn, websocket: websocket}, error}
         end
 
       {:error, websocket, error} ->
-        {:error, %{data | websocket: websocket}, error}
+        {:error, %{state | websocket: websocket}, error}
     end
+  end
+
+  defp internal_event(message) do
+    send(self(), {@internal, message})
+  end
+
+  defp internal_event(message, delay) do
+    Process.send_after(self(), {@internal, message}, delay)
   end
 end

--- a/lib/minch/simple_client.ex
+++ b/lib/minch/simple_client.ex
@@ -2,10 +2,9 @@ defmodule Minch.SimpleClient do
   @moduledoc false
   use Minch
 
-  defmodule State do
-    @moduledoc false
-    defstruct [:url, :headers, :options, :receiver, :receiver_ref, :monitor_ref, :connected?]
-  end
+  alias __MODULE__, as: State
+
+  defstruct [:url, :headers, :options, :receiver, :receiver_ref, :monitor_ref, :connected?]
 
   @spec start(String.t() | URI.t(), Mint.Types.headers(), Keyword.t()) ::
           {:ok, pid(), reference()} | {:error, Mint.WebSocket.error() | :timeout}
@@ -59,7 +58,7 @@ defmodule Minch.SimpleClient do
       send(state.receiver, {:connection_error, state.receiver_ref, reason})
     end
 
-    {:stop, {:shutdown, reason}}
+    {:stop, {:shutdown, reason}, state}
   end
 
   @impl true
@@ -69,7 +68,7 @@ defmodule Minch.SimpleClient do
   end
 
   @impl true
-  def handle_info({:DOWN, ref, :process, _pid, _reason}, %State{monitor_ref: ref}) do
-    {:stop, {:shutdown, :receiver_down}}
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %State{monitor_ref: ref} = state) do
+    {:stop, {:shutdown, :receiver_down}, state}
   end
 end

--- a/test/minch/simple_client_test.exs
+++ b/test/minch/simple_client_test.exs
@@ -31,7 +31,7 @@ defmodule Minch.SimpleClientTest do
   test "sends received frames to the parent process", %{url: url} do
     {:ok, _pid, ref} = Minch.connect(url)
     assert_receive {:server, :init, server}
-    :ok = Server.send_frame(server, {:text, "hello"})
+    Server.send_frame(server, {:text, "hello"})
     assert {:text, "hello"} = Minch.receive_frame(ref)
   end
 
@@ -57,7 +57,7 @@ defmodule Minch.SimpleClientTest do
     {:ok, pid, _ref} = Minch.connect(url)
     monitor_ref = Process.monitor(pid)
     assert_receive {:server, :init, server}
-    :ok = Server.send_frame(server, {:close, 1000, "test"})
-    assert_receive {:DOWN, ^monitor_ref, :process, _pid, {:shutdown, {:close, 1000, "test"}}}
+    Server.send_frame(server, :close)
+    assert_receive {:DOWN, ^monitor_ref, :process, _pid, {:shutdown, _}}
   end
 end


### PR DESCRIPTION
GenServer implementations feels more simple compared to :gen_statem

BEGIN_COMMIT_OVERRIDE
feat: add `{:stop, reason, state}` result to some callbacks
END_COMMIT_OVERRIDE